### PR TITLE
fix api list tables func getTablesWithSkip

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -491,6 +491,7 @@ func (api *APIServer) getTablesWithSkip(tables []clickhouse.Table) []clickhouse.
 	for _, t := range tables {
 		if !t.Skip {
 			showTables[showCounts] = t
+			showCounts++
 		}
 	}
 	return showTables


### PR DESCRIPTION
fix api list tables  func getTablesWithSkip